### PR TITLE
docs: update lint check in readme doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,6 @@ This is a small test repository that serves to test linting of PR
 
 It exists to check that PR have labels
 
+## Lint checks
+
+- Check that the PR when opened has a label


### PR DESCRIPTION
add lint description for label must be present on readme

test to see if warning message displayed that PR does not have a label